### PR TITLE
Change 'get_entry_map' to take only a single dist

### DIFF
--- a/reentry/jsonbackend.py
+++ b/reentry/jsonbackend.py
@@ -167,11 +167,8 @@ class JsonBackend(BackendInterface):
         from collections import Sequence
         from reentry.entrypoint import EntryPoint
         '''sanitize dist kwarg'''
-        if dist is None:
-            dist = self.get_dist_names()
-        if not isinstance(dist, Sequence) or isinstance(dist, (str, unicode)):
-            dist = [dist]
-        dist = [d for d in dist if d in self.epmap]
+        if dist not in self.epmap:
+            raise ValueError("The {} distribution was not found.".format(dist))
 
         '''sanitize groups kwarg'''
         if group is None:
@@ -184,17 +181,13 @@ class JsonBackend(BackendInterface):
             if not isinstance(name, Sequence) or isinstance(name, (str, unicode)):
                 name = [name]
 
-        emap = {}
-        for d in dist:
-            dmap = {}
-            for g in group:
-                if g in self.epmap[d].keys():
-                    gmap = {}
-                    for n, e in self.epmap[d][g].iteritems():
-                        if not name or any([re.match(i, n) for i in name]):
-                            gmap[n] = EntryPoint.parse(e)
-                    if gmap:
-                        dmap[g] = gmap
-            if dmap:
-                emap[d] = dmap
-        return emap
+        dmap = {}
+        for g in group:
+            if g in self.epmap[dist].keys():
+                gmap = {}
+                for n, e in self.epmap[dist][g].iteritems():
+                    if not name or any([re.match(i, n) for i in name]):
+                        gmap[n] = EntryPoint.parse(e)
+                if gmap:
+                    dmap[g] = gmap
+        return dmap


### PR DESCRIPTION
* directly return map for this dist, instead of a dict of maps
* makes it consistent with the pkg_resources API

This API inconsistency created a bug in AiiDA, where a plugin calculation node is of generic ``JobCalculation`` type after storing / retrieving. The reason is because AiiDA assumes that the ``dict`` returned by ``get_entry_map`` has the keys (``aiida.calculation``, ...) on the top level, while here it was ``{'aiida-core': {'aiida.calculation':...}}``.

If you want to keep the ability to have multiple ``dists`` (which ``pkg_resources`` doesn't), the API should be changed such that it behaves the same as ``pkg_resources`` when a single string is passed.