### PR TITLE
Fixing collections.abc import

### DIFF
--- a/reentry/__init__.py
+++ b/reentry/__init__.py
@@ -1,5 +1,5 @@
 """Expose the default manager"""
 from reentry.default_manager import DEFAULT_MANAGER as manager
 
-__version__ = '1.3.1'
+__version__ = '1.3.2'
 __all__ = ['manager']

--- a/reentry/jsonbackend.py
+++ b/reentry/jsonbackend.py
@@ -282,7 +282,7 @@ class JsonBackend(BackendInterface):
 
 def _listify(sequence_or_name):
     """Wrap a single name in a list, leave sequences and None unchanged"""
-    from collections import Sequence  # pylint: disable=no-name-in-module
+    from collections.abc import Sequence
     # pylint: disable=no-else-return
     if sequence_or_name is None:
         return None

--- a/reentry/jsonbackend.py
+++ b/reentry/jsonbackend.py
@@ -282,10 +282,10 @@ class JsonBackend(BackendInterface):
 
 def _listify(sequence_or_name):
     """Wrap a single name in a list, leave sequences and None unchanged"""
-    from collections.abc import Sequence
-    # pylint: disable=no-else-return
+    from six.moves import collections_abc
+
     if sequence_or_name is None:
         return None
-    elif not isinstance(sequence_or_name, Sequence) or isinstance(sequence_or_name, six.string_types):
+    if not isinstance(sequence_or_name, collections_abc.Sequence) or isinstance(sequence_or_name, six.string_types):
         return [sequence_or_name]
     return sequence_or_name

--- a/setup.json
+++ b/setup.json
@@ -1,8 +1,9 @@
 {
     "name": "reentry",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "author": "Rico Haeuselmann",
     "license": "MIT License",
+    "url": "https://github.com/dropd/reentry",
     "description": "A plugin manager based on setuptools entry points mechanism",
     "entry_points": {
         "distutils.setup_keywords": [


### PR DESCRIPTION
I now fix the collections.abc.Sequence import, that was
being imported as collections.Sequence instead, raising warnings
(and will not work in py 3.10).
This fixes #57 

I also add a "url" field in the setup.json, so on pypi there will
be a link back to the repository (fixes #56)

Version upped to 1.3.2 to make this ready for a new release.